### PR TITLE
74 deprecationwarning the warn method is deprecated use warning instead

### DIFF
--- a/Lib/compositing.py
+++ b/Lib/compositing.py
@@ -366,7 +366,7 @@ class compositing(object):
         if grafield:
           result.addParameter(grafield)
         else:
-          self.logger.warn(f"[{self.mpname}] compositing.generate: Failed to generate gra field....")
+          self.logger.warning(f"[{self.mpname}] compositing.generate: Failed to generate gra field....")
     
     # Hack to create a BRDR field if the qfields contains se.smhi.composite.index.radar
     if "se.smhi.composite.index.radar" in qfields:
@@ -518,7 +518,7 @@ class compositing(object):
         is_pvol = _polarvolume.isPolarVolume(obj)
         
       if not is_scan and not is_pvol:
-        self.logger.warn(f"[{self.mpname}] compositing.fetch_objects: Input file {fname} is neither polar scan or volume, ignoring.")
+        self.logger.warning(f"[{self.mpname}] compositing.fetch_objects: Input file {fname} is neither polar scan or volume, ignoring.")
         continue
       
       # Force azimuthal nav information usage if requested
@@ -611,7 +611,7 @@ class compositing(object):
       logger.exception("Failed to aquire coefficients")
 
     dtstr = agedt.strftime("%Y%m%d %H:%M:%S")
-    logger.warn(f"[{self.mpname}] compositing.get_backup_gra_coefficient: Could not aquire coefficients newer than {dtstr}, defaulting to climatologic")
+    logger.warning(f"[{self.mpname}] compositing.get_backup_gra_coefficient: Could not aquire coefficients newer than {dtstr}, defaulting to climatologic")
     return "False", 0, 0, 0.0, "False", 0.0, DEFAULTA, DEFAULTB, DEFAULTC, 0.0, 0.0
   
   ##

--- a/Lib/fm12_importer.py
+++ b/Lib/fm12_importer.py
@@ -72,7 +72,7 @@ class fm12_importer(object):
       except:
         os.kill(int(c), signal.SIGKILL)
     except:
-      self._logger.warn("Failed to kill daemon. Check pid!")
+      self._logger.warning("Failed to kill daemon. Check pid!")
       print("Could not kill daemon. Check pid.")
     finally:
       os.remove(self.pidfile)

--- a/Lib/rave_dom_db.py
+++ b/Lib/rave_dom_db.py
@@ -216,12 +216,12 @@ class rave_db(object):
   def psql_invalidate(self, dbapi_conn, connection_rec, exception):
     if exception != None and isinstance(exception, OperationalError):
       if "server closed the connection unexpectedly" in exception.message:
-        logger.warn("Got invalidation message indicating that there has been connection problems. Recreating pool.")
+        logger.warning("Got invalidation message indicating that there has been connection problems. Recreating pool.")
         self._engine.dispose()
     elif exception != None and isinstance(exception,  psycopg2.OperationalError):
-      logger.warn("psycopg2,OperationalError will be tested")
+      logger.warning("psycopg2,OperationalError will be tested")
       if "server closed the connection unexpectedly" in exception.message:
-        logger.warn("Got invalidation message indicating that there has been connection problems. Recreating pool.")
+        logger.warning("Got invalidation message indicating that there has been connection problems. Recreating pool.")
         self._engine.dispose()
 
   ##

--- a/Lib/rave_pgf_acrr_plugin.py
+++ b/Lib/rave_pgf_acrr_plugin.py
@@ -98,7 +98,7 @@ def get_backup_gra_coefficient(db, agedt, nowdt):
   except Exception:
     logger.exception("Failed to aquire coefficients")
 
-  logger.warn("Could not aquire coefficients newer than %s, defaulting to climatologic"%agedt.strftime("%Y%m%d %H:%M:%S"))
+  logger.warning("Could not aquire coefficients newer than %s, defaulting to climatologic"%agedt.strftime("%Y%m%d %H:%M:%S"))
   return "False", 0, 0, 0.0, "False", 0.0, DEFAULTA, DEFAULTB, DEFAULTC, 0.0, 0.0
 
 ## Creates a composite
@@ -200,7 +200,7 @@ def generate(files, arguments):
 
     par = obj.getParameter(quantity)
     if par == None:
-      logger.warn("Could not find parameter (%s) for %s %s"%(quantity, obj.date, obj.time))
+      logger.warning("Could not find parameter (%s) for %s %s"%(quantity, obj.date, obj.time))
     else:
       if par.getQualityFieldByHowTask(distancefield) != None:
         acrr.sum(par, zr_a, zr_b)

--- a/Lib/rave_pgf_gra_plugin.py
+++ b/Lib/rave_pgf_gra_plugin.py
@@ -108,7 +108,7 @@ def get_backup_gra_coefficient(db, maxage):
     logger.exception(f"[{mpname}] rave_pgf_gra_plugin.get_backup_gra_coefficient: Failed to aquire coefficients")
 
   dtstr = maxage.strftime("%Y%m%d %H:%M:%S")
-  logger.warn(f"[{mpname}] rave_pgf_gra_plugin.get_backup_gra_coefficient: Could not aquire coefficients newer than {dtstr}, defaulting to climatologic")
+  logger.warning(f"[{mpname}] rave_pgf_gra_plugin.get_backup_gra_coefficient: Could not aquire coefficients newer than {dtstr}, defaulting to climatologic")
   return "False", 0, 0, 0.0, "False", 0.0, DEFAULTA, DEFAULTB, DEFAULTC, 0.0, 0.0
   
 ## Creates a composite
@@ -123,7 +123,7 @@ def calculate_gra_coefficient(distancefield, interval, adjustmentfile, etime, ed
   logger.info(f"[{mpname}] rave_pgf_gra_plugin.calculate_gra_coefficient: Matching observations")
   points = matcher.match(acrrproduct, acc_period=interval, quantity="ACRR", how_task=distancefield)
   if len(points) == 0:
-    logger.warn(f"[{mpname}] rave_pgf_gra_plugin.calculate_gra_coefficient: Could not find any matching observations")
+    logger.warning(f"[{mpname}] rave_pgf_gra_plugin.calculate_gra_coefficient: Could not find any matching observations")
   else:
     logger.info(f"[{mpname}] rave_pgf_gra_plugin.calculate_gra_coefficient: Matched {len(points)} points between acrr product and observation db")
     db.merge(points)
@@ -252,7 +252,7 @@ def generate(files, arguments):
 
     par = obj.getParameter(quantity)
     if par == None:
-      logger.warn(f"[{mpname}] rave_pgf_gra_plugin.generate: Could not find parameter ({quantity}) for {obj.date} {obj.time}")
+      logger.warning(f"[{mpname}] rave_pgf_gra_plugin.generate: Could not find parameter ({quantity}) for {obj.date} {obj.time}")
     else:
       if par.getQualityFieldByHowTask(distancefield) != None:
         acrr.sum(par, zr_a, zr_b)
@@ -271,7 +271,7 @@ def generate(files, arguments):
     logger.info(f"[{mpname}] rave_pgf_gra_plugin.generate: Coefficients calculated")
   except OperationalError as e:
     if "server closed the connection unexpectedly" in e.message:
-      logger.warn(f"[{mpname}] rave_pgf_gra_plugin.generate: Got indication that connection reseted at server side, retrying gra coefficient generation")
+      logger.warning(f"[{mpname}] rave_pgf_gra_plugin.generate: Got indication that connection reseted at server side, retrying gra coefficient generation")
       calculate_gra_coefficient(distancefield, interval, adjustmentfile, etime, edate, acrrproduct, db)
 
   exectime = int((time.time() - entertime)*1000)

--- a/Lib/tiled_compositing.py
+++ b/Lib/tiled_compositing.py
@@ -565,7 +565,7 @@ class tiled_compositing(object):
       for v in results[0]:
         tile_file = v[1]
         if tile_file == None:
-          self.logger.warn(f"[{self.mpname}] tiled_compositing.generate: No partial composite for tile area {v[0]} was created. This tile will therefore not be included in complete composite.")
+          self.logger.warning(f"[{self.mpname}] tiled_compositing.generate: No partial composite for tile area {v[0]} was created. This tile will therefore not be included in complete composite.")
         else:
           o = _raveio.open(tile_file).object
           if _cartesianvolume.isCartesianVolume(o):
@@ -597,7 +597,7 @@ class tiled_compositing(object):
           try:
             os.unlink(fname)
           except:
-            logger.warn(f"[{self.mpname}] tiled_compositing.generate: Failed to remove temporary file: {fname}")
+            logger.warning(f"[{self.mpname}] tiled_compositing.generate: Failed to remove temporary file: {fname}")
       
       if results != None:
         for v in results[0]:

--- a/bin/create_acrr_composites
+++ b/bin/create_acrr_composites
@@ -137,7 +137,7 @@ def generate_comp(filepath, pattern, fdate, ftime, areaid="allbltgmaps_4000", op
     return filename
   files = glob.glob("%s/%s"%(filepath, pattern)) #se*_pvol*.h5
   if len(files) == 0:
-    logger.warn("No files found for %s/%s"%(filepath, pattern))
+    logger.warning("No files found for %s/%s"%(filepath, pattern))
     return filename
   comp = compositing(ravebdb)
   comp.height = height
@@ -267,7 +267,7 @@ def generate_acrr(files, opath, areaid, etime, edate, startdt, enddt, zr_a=200.0
       raise AttributeError("Scale or projdef inconsistancy for used area")
     par = obj.getParameter(quantity)
     if par == None:
-      logger.warn("Could not find parameter (%s) for %s %s"%(acrr_quantity, obj.date, obj.time))
+      logger.warning("Could not find parameter (%s) for %s %s"%(acrr_quantity, obj.date, obj.time))
     else:
       pdfield = par.getQualityFieldByHowTask(distancefield) 
       if pdfield != None:
@@ -363,7 +363,7 @@ def generate_gra(files, opath, areaid, etime, edate, startdt, enddt, zr_a=200.0,
 
     par = obj.getParameter(quantity)
     if par == None:
-      logger.warn("Could not find parameter (%s) for %s %s"%(quantity, obj.date, obj.time))
+      logger.warning("Could not find parameter (%s) for %s %s"%(quantity, obj.date, obj.time))
     else:
       if par.getQualityFieldByHowTask(distancefield) != None:
         acrr.sum(par, zr_a, zr_b)
@@ -380,7 +380,7 @@ def generate_gra(files, opath, areaid, etime, edate, startdt, enddt, zr_a=200.0,
   
   points = matcher.match(acrrproduct, acc_period=interval, quantity="ACRR", how_task=distancefield, offset_hours=interval)
   if len(points) == 0:
-    logger.warn("Could not find any matching observations")
+    logger.warning("Could not find any matching observations")
     return None
   
   logger.info("Matched %d points between acrr product and observation db"%len(points))
@@ -535,4 +535,3 @@ if __name__=="__main__":
                                   options.pattern, options.applygra, zr_a=ZR_a, zr_b=ZR_b)
 
     
-  

--- a/bin/odim_injector
+++ b/bin/odim_injector
@@ -198,20 +198,20 @@ def MAIN(in_file, janitor=False, uri=DEX_SPOE):
               if os.path.isfile(in_file):
                 removed = remove_file(in_file)
             else:
-              pyinotify.log.warn(in_file + " not ODIM_H5, removed.")
+              pyinotify.log.warning(in_file + " not ODIM_H5, removed.")
               removed = remove_file(in_file)
           except Exception as e:
             pyinotify.log.error("%s" % e)
             removed = remove_file(in_file)
 
       else:
-        pyinotify.log.warn(in_file + " not HDF5, removed.")
+        pyinotify.log.warning(in_file + " not HDF5, removed.")
         removed = remove_file(in_file)
     else:
-      pyinotify.log.warn(in_file + " is zero length, removed.")
+      pyinotify.log.warning(in_file + " is zero length, removed.")
       removed = remove_file(in_file)
   else:
-    pyinotify.log.warn(in_file + " not a regular file, ignored.")
+    pyinotify.log.warning(in_file + " not a regular file, ignored.")
     
   return removed
 


### PR DESCRIPTION
Fixes: https://github.com/baltrad/rave/issues/74

Any call to `warn(` has been replaced with: `warning(`.

Related:
* #75 
* #73 
